### PR TITLE
chore: update docs accordingly as described in ticket #89

### DIFF
--- a/src/0.8.0/jumpstart.md
+++ b/src/0.8.0/jumpstart.md
@@ -269,22 +269,22 @@ ctx = metadata.NewOutgoingContext(context.Background(), md)
 
 ::: tab Java
 This feature is not yet supported or not documented.
-Do you want to make a feature request or help out? Open an issue on [java sdk github project](https://github.com/codenotary/immudb4j/issues/new)
+Do you want to make a feature request or help out? Open an issue on [Java sdk github project](https://github.com/codenotary/immudb4j/issues/new)
 :::
 
 ::: tab Python
 This feature is not yet supported or not documented.
-Do you want to make a feature request or help out? Open an issue on [java sdk github project](https://github.com/codenotary/immudb-py/issues/new)
+Do you want to make a feature request or help out? Open an issue on [Python sdk github project](https://github.com/codenotary/immudb-py/issues/new)
 :::
 
 ::: tab Node.js
 This feature is not yet supported or not documented.
-Do you want to make a feature request or help out? Open an issue on [java sdk github project](https://github.com/codenotary/immudb-node/issues/new)
+Do you want to make a feature request or help out? Open an issue on [Node.js sdk github project](https://github.com/codenotary/immudb-node/issues/new)
 :::
 
 ::: tab .Net
 This feature is not yet supported or not documented.
-Do you want to make a feature request or help out? Open an issue on [java sdk github project](https://github.com/codenotary/immudb4dotnet/issues/new)
+Do you want to make a feature request or help out? Open an issue on [.Net sdk github project](https://github.com/codenotary/immudb4dotnet/issues/new)
 :::
 
 ::: tab Others

--- a/src/0.8.1/jumpstart.md
+++ b/src/0.8.1/jumpstart.md
@@ -244,22 +244,22 @@ ctx = metadata.NewOutgoingContext(context.Background(), md)
 
 ::: tab Java
 This feature is not yet supported or not documented.
-Do you want to make a feature request or help out? Open an issue on [java sdk github project](https://github.com/codenotary/immudb4j/issues/new)
+Do you want to make a feature request or help out? Open an issue on [Java sdk github project](https://github.com/codenotary/immudb4j/issues/new)
 :::
 
 ::: tab Python
 This feature is not yet supported or not documented.
-Do you want to make a feature request or help out? Open an issue on [java sdk github project](https://github.com/codenotary/immudb-py/issues/new)
+Do you want to make a feature request or help out? Open an issue on [Python sdk github project](https://github.com/codenotary/immudb-py/issues/new)
 :::
 
 ::: tab Node.js
 This feature is not yet supported or not documented.
-Do you want to make a feature request or help out? Open an issue on [java sdk github project](https://github.com/codenotary/immudb-node/issues/new)
+Do you want to make a feature request or help out? Open an issue on [Node.js sdk github project](https://github.com/codenotary/immudb-node/issues/new)
 :::
 
 ::: tab .Net
 This feature is not yet supported or not documented.
-Do you want to make a feature request or help out? Open an issue on [java sdk github project](https://github.com/codenotary/immudb4dotnet/issues/new)
+Do you want to make a feature request or help out? Open an issue on [.Net sdk github project](https://github.com/codenotary/immudb4dotnet/issues/new)
 :::
 
 ::: tab Others

--- a/src/0.9.0/jumpstart.md
+++ b/src/0.9.0/jumpstart.md
@@ -269,22 +269,22 @@ ctx = metadata.NewOutgoingContext(context.Background(), md)
 
 ::: tab Java
 This feature is not yet supported or not documented.
-Do you want to make a feature request or help out? Open an issue on [java sdk github project](https://github.com/codenotary/immudb4j/issues/new)
+Do you want to make a feature request or help out? Open an issue on [Java sdk github project](https://github.com/codenotary/immudb4j/issues/new)
 :::
 
 ::: tab Python
 This feature is not yet supported or not documented.
-Do you want to make a feature request or help out? Open an issue on [java sdk github project](https://github.com/codenotary/immudb-py/issues/new)
+Do you want to make a feature request or help out? Open an issue on [Python sdk github project](https://github.com/codenotary/immudb-py/issues/new)
 :::
 
 ::: tab Node.js
 This feature is not yet supported or not documented.
-Do you want to make a feature request or help out? Open an issue on [java sdk github project](https://github.com/codenotary/immudb-node/issues/new)
+Do you want to make a feature request or help out? Open an issue on [Node.js sdk github project](https://github.com/codenotary/immudb-node/issues/new)
 :::
 
 ::: tab .Net
 This feature is not yet supported or not documented.
-Do you want to make a feature request or help out? Open an issue on [java sdk github project](https://github.com/codenotary/immudb4dotnet/issues/new)
+Do you want to make a feature request or help out? Open an issue on [.Net sdk github project](https://github.com/codenotary/immudb4dotnet/issues/new)
 :::
 
 ::: tab Others

--- a/src/0.9.1/jumpstart.md
+++ b/src/0.9.1/jumpstart.md
@@ -20,7 +20,7 @@
 ## Introduction
 This guide helps developers quickly start with CodeNotary's immudb database and client. It guides you from start to finish with code samples in Node.js, Java, Python, Go, and .Net. After completing the guide, you will have the basic concepts necessary to begin using immudb within your organization.
 
-Note: If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+Note: If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 
 This section is not yet ready for immudb 0.9. We are working on it in order to improve it and we are close to deliver. Stay tuned!
 
@@ -234,7 +234,7 @@ Creating a Client.
 :::
 
 ::: tab Others
-If you're using another language, then read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another language, then read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -269,26 +269,26 @@ ctx = metadata.NewOutgoingContext(context.Background(), md)
 
 ::: tab Java
 This feature is not yet supported or not documented.
-Do you want to make a feature request or help out? Open an issue on [java sdk github project](https://github.com/codenotary/immudb4j/issues/new)
+Do you want to make a feature request or help out? Open an issue on [Java sdk github project](https://github.com/codenotary/immudb4j/issues/new)
 :::
 
 ::: tab Python
 This feature is not yet supported or not documented.
-Do you want to make a feature request or help out? Open an issue on [java sdk github project](https://github.com/codenotary/immudb-py/issues/new)
+Do you want to make a feature request or help out? Open an issue on [Python sdk github project](https://github.com/codenotary/immudb-py/issues/new)
 :::
 
 ::: tab Node.js
 This feature is not yet supported or not documented.
-Do you want to make a feature request or help out? Open an issue on [java sdk github project](https://github.com/codenotary/immudb-node/issues/new)
+Do you want to make a feature request or help out? Open an issue on [Node.js sdk github project](https://github.com/codenotary/immudb-node/issues/new)
 :::
 
 ::: tab .Net
 This feature is not yet supported or not documented.
-Do you want to make a feature request or help out? Open an issue on [java sdk github project](https://github.com/codenotary/immudb4dotnet/issues/new)
+Do you want to make a feature request or help out? Open an issue on [.Net sdk github project](https://github.com/codenotary/immudb4dotnet/issues/new)
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -338,7 +338,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/0.9.1/sdks-api.md
+++ b/src/0.9.1/sdks-api.md
@@ -123,7 +123,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -180,7 +180,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -243,7 +243,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -359,7 +359,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -462,7 +462,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -557,7 +557,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -656,7 +656,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -767,7 +767,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -857,7 +857,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -947,7 +947,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -1041,7 +1041,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -1078,7 +1078,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -1270,7 +1270,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -1442,7 +1442,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -1540,7 +1540,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -1648,7 +1648,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -1861,7 +1861,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -1956,7 +1956,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -2033,7 +2033,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -2196,7 +2196,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -2336,7 +2336,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -2401,7 +2401,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -2539,7 +2539,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -2677,7 +2677,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -2727,7 +2727,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -2784,7 +2784,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/0.9.2/jumpstart.md
+++ b/src/0.9.2/jumpstart.md
@@ -5,7 +5,7 @@
 ## Introduction
 This guide helps developers quickly start with CodeNotary's immudb database and client. It guides you from start to finish with code samples in Node.js, Java, Python, Go, and .Net. After completing the guide, you will have the basic concepts necessary to begin using immudb within your organization.
 
-Note: If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+Note: If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 
 This section is not yet ready for immudb 0.9. We are working on it in order to improve it and we are close to deliver. Stay tuned!
 
@@ -209,7 +209,7 @@ Creating a Client.
 :::
 
 ::: tab Others
-If you're using another language, then read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another language, then read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -244,26 +244,26 @@ ctx = metadata.NewOutgoingContext(context.Background(), md)
 
 ::: tab Java
 This feature is not yet supported or not documented.
-Do you want to make a feature request or help out? Open an issue on [java sdk github project](https://github.com/codenotary/immudb4j/issues/new)
+Do you want to make a feature request or help out? Open an issue on [Java sdk github project](https://github.com/codenotary/immudb4j/issues/new)
 :::
 
 ::: tab Python
 This feature is not yet supported or not documented.
-Do you want to make a feature request or help out? Open an issue on [java sdk github project](https://github.com/codenotary/immudb-py/issues/new)
+Do you want to make a feature request or help out? Open an issue on [Python sdk github project](https://github.com/codenotary/immudb-py/issues/new)
 :::
 
 ::: tab Node.js
 This feature is not yet supported or not documented.
-Do you want to make a feature request or help out? Open an issue on [java sdk github project](https://github.com/codenotary/immudb-node/issues/new)
+Do you want to make a feature request or help out? Open an issue on [Node.js sdk github project](https://github.com/codenotary/immudb-node/issues/new)
 :::
 
 ::: tab .Net
 This feature is not yet supported or not documented.
-Do you want to make a feature request or help out? Open an issue on [java sdk github project](https://github.com/codenotary/immudb4dotnet/issues/new)
+Do you want to make a feature request or help out? Open an issue on [.Net sdk github project](https://github.com/codenotary/immudb4dotnet/issues/new)
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -313,7 +313,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/0.9.2/sdks-api.md
+++ b/src/0.9.2/sdks-api.md
@@ -88,7 +88,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -145,7 +145,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -208,7 +208,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -324,7 +324,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -427,7 +427,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -522,7 +522,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -621,7 +621,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -732,7 +732,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -822,7 +822,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -912,7 +912,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -1006,7 +1006,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -1043,7 +1043,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -1235,7 +1235,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -1407,7 +1407,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -1505,7 +1505,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -1613,7 +1613,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -1826,7 +1826,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -1921,7 +1921,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -1998,7 +1998,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -2161,7 +2161,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -2301,7 +2301,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -2366,7 +2366,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -2504,7 +2504,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -2642,7 +2642,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -2692,7 +2692,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -2749,7 +2749,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/1.0.0/develop/connection.md
+++ b/src/1.0.0/develop/connection.md
@@ -66,7 +66,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -143,7 +143,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -206,7 +206,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/1.0.0/develop/history.md
+++ b/src/1.0.0/develop/history.md
@@ -87,7 +87,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -126,7 +126,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -320,7 +320,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -494,7 +494,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -594,7 +594,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -702,7 +702,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/1.0.0/develop/indexes.md
+++ b/src/1.0.0/develop/indexes.md
@@ -206,7 +206,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/1.0.0/develop/management.md
+++ b/src/1.0.0/develop/management.md
@@ -130,7 +130,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -260,7 +260,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -309,7 +309,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -364,7 +364,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/1.0.0/develop/operations.md
+++ b/src/1.0.0/develop/operations.md
@@ -109,7 +109,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -212,7 +212,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -309,7 +309,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/1.0.0/develop/reading.md
+++ b/src/1.0.0/develop/reading.md
@@ -92,7 +92,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -203,7 +203,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -293,7 +293,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -383,7 +383,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/1.0.0/develop/streams.md
+++ b/src/1.0.0/develop/streams.md
@@ -108,7 +108,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -173,7 +173,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/1.0.0/develop/transactions.md
+++ b/src/1.0.0/develop/transactions.md
@@ -88,7 +88,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -165,7 +165,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -328,7 +328,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -468,7 +468,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/1.0.0/develop/utilities.md
+++ b/src/1.0.0/develop/utilities.md
@@ -57,7 +57,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/1.0.0/jumpstart.md
+++ b/src/1.0.0/jumpstart.md
@@ -34,7 +34,7 @@ SDKs make it comfortable to talk to the server from your favourite language, wit
 
 The most well-known immudb SDK is written in [Golang](https://golang.org/), but there are SDKs available for Python, NodeJS, Java and others.
 
-For other unsupported programming languages, [immugw](https://docs.immudb.io/master/immugw/) provides a REST gateway that can be used to talk to the server via generic HTTP.
+For other unsupported programming languages, [immugw](/master/immugw/) provides a REST gateway that can be used to talk to the server via generic HTTP.
 
 </WrappedSection>
 
@@ -170,7 +170,7 @@ Creating a Client.
 :::
 
 ::: tab Others
-If you're using another language, then read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another language, then read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -248,11 +248,11 @@ const cl = new ImmudbClient();
 
 ::: tab .Net
 This feature is not yet supported or not documented.
-Do you want to make a feature request or help out? Open an issue on [java sdk github project](https://github.com/codenotary/immudb4dotnet/issues/new)
+Do you want to make a feature request or help out? Open an issue on [.Net sdk github project](https://github.com/codenotary/immudb4dotnet/issues/new)
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -302,7 +302,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/1.1.0/develop/connection.md
+++ b/src/1.1.0/develop/connection.md
@@ -66,7 +66,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -143,7 +143,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -206,7 +206,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/1.1.0/develop/history.md
+++ b/src/1.1.0/develop/history.md
@@ -87,7 +87,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -126,7 +126,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -320,7 +320,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -494,7 +494,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -594,7 +594,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -702,7 +702,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/1.1.0/develop/indexes.md
+++ b/src/1.1.0/develop/indexes.md
@@ -206,7 +206,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/1.1.0/develop/management.md
+++ b/src/1.1.0/develop/management.md
@@ -130,7 +130,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -260,7 +260,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -309,7 +309,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -364,7 +364,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/1.1.0/develop/operations.md
+++ b/src/1.1.0/develop/operations.md
@@ -110,7 +110,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -213,7 +213,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -310,7 +310,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/1.1.0/develop/reading.md
+++ b/src/1.1.0/develop/reading.md
@@ -92,7 +92,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -203,7 +203,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -293,7 +293,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -383,7 +383,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/1.1.0/develop/streams.md
+++ b/src/1.1.0/develop/streams.md
@@ -108,7 +108,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -173,7 +173,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/1.1.0/develop/transactions.md
+++ b/src/1.1.0/develop/transactions.md
@@ -88,7 +88,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -165,7 +165,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -328,7 +328,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -468,7 +468,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/1.1.0/develop/utilities.md
+++ b/src/1.1.0/develop/utilities.md
@@ -57,7 +57,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/1.1.0/jumpstart.md
+++ b/src/1.1.0/jumpstart.md
@@ -34,7 +34,7 @@ SDKs make it comfortable to talk to the server from your favourite language, wit
 
 The most well-known immudb SDK is written in [Golang](https://golang.org/), but there are SDKs available for Python, NodeJS, Java and others.
 
-For other unsupported programming languages, [immugw](https://docs.immudb.io/master/immugw/) provides a REST gateway that can be used to talk to the server via generic HTTP.
+For other unsupported programming languages, [immugw](/master/immugw/) provides a REST gateway that can be used to talk to the server via generic HTTP.
 
 </WrappedSection>
 
@@ -171,7 +171,7 @@ Creating a Client.
 :::
 
 ::: tab Others
-If you're using another language, then read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another language, then read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -249,11 +249,11 @@ const cl = new ImmudbClient();
 
 ::: tab .Net
 This feature is not yet supported or not documented.
-Do you want to make a feature request or help out? Open an issue on [java sdk github project](https://github.com/codenotary/immudb4dotnet/issues/new)
+Do you want to make a feature request or help out? Open an issue on [.Net sdk github project](https://github.com/codenotary/immudb4dotnet/issues/new)
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -303,7 +303,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/master/develop/connection.md
+++ b/src/master/develop/connection.md
@@ -66,7 +66,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -143,7 +143,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -206,7 +206,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/master/develop/history.md
+++ b/src/master/develop/history.md
@@ -87,7 +87,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -126,7 +126,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -320,7 +320,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -494,7 +494,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -594,7 +594,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -702,7 +702,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/master/develop/indexes.md
+++ b/src/master/develop/indexes.md
@@ -206,7 +206,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/master/develop/management.md
+++ b/src/master/develop/management.md
@@ -130,7 +130,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -260,7 +260,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -309,7 +309,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -364,7 +364,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/master/develop/operations.md
+++ b/src/master/develop/operations.md
@@ -110,7 +110,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -213,7 +213,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -310,7 +310,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/master/develop/reading.md
+++ b/src/master/develop/reading.md
@@ -92,7 +92,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -203,7 +203,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -293,7 +293,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -383,7 +383,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/master/develop/streams.md
+++ b/src/master/develop/streams.md
@@ -108,7 +108,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -173,7 +173,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/master/develop/transactions.md
+++ b/src/master/develop/transactions.md
@@ -88,7 +88,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -165,7 +165,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -328,7 +328,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -468,7 +468,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/master/develop/utilities.md
+++ b/src/master/develop/utilities.md
@@ -57,7 +57,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::

--- a/src/master/immugw/curl.md
+++ b/src/master/immugw/curl.md
@@ -1,0 +1,2 @@
+# Curl Examples 0.9.0
+This section is not yet ready for immudb 0.9. We are working on it in order to improve it and we are close to deliver. Stay tuned!

--- a/src/master/immugw/index.md
+++ b/src/master/immugw/index.md
@@ -1,0 +1,263 @@
+---
+title: Overview
+---
+
+# immugw
+
+immugw is the intelligent REST proxy that connects to immudb and provides a RESTful interface for applications. We recommend running immudb and immugw on separate machines to enhance security
+immugw can be found in a different [repository](https://github.com/codenotary/immugw)
+
+## Contents
+ - [Latest binaries](#latest-binaries)
+ - [Build](#build)
+ - [Docker](#docker)
+ - [Run immugw](#run-immugw)
+ - [Configuration](#configuration)
+ - [immuadmin](#immuadmin)
+ - [immugw service](#immugw-service)
+ - [Use immugw](#use-immugw)
+ - [API](#api)
+ - [Auditor](#auditor)
+ - [License](#license)
+
+## Latest binaries
+
+[Get the latest builds](https://github.com/codenotary/immugw/releases/latest)
+
+## Build
+
+clone the immugw repository locally
+
+'git clone https://github.com/codenotary/immugw.git'
+
+### Linux
+
+```bash
+GOOS=linux GOARCH=amd64 make immugw-static
+```
+
+### MacOS
+
+```bash
+GOOS=darwin GOARCH=amd64 make immugw-static
+```
+
+### Windows
+
+```bash
+GOOS=windows GOARCH=amd64 make immugw-static
+```
+
+## Docker
+
+### build your own Docker container image
+```bash
+docker build -t myown/immugw:latest -f Dockerfile .
+```
+
+### run immugw in a container
+Make sure to point to the immudb system using the environment variable IMMUGW_IMMUDB_ADDRESS
+
+```
+docker run -it -d -p 3323:3323 --name immugw --env IMMUGW_IMMUDB_ADDRESS=immudb codenotary/immugw:latest
+```
+
+## Run immugw
+
+Simply run ```./immugw -d``` to start immugw on the same machine as immudb (test or dev environment) or pointing to the remote immudb system ```./immugw --immudb-address "immudb-server"```.
+
+If you want to stop immugw în that case you need to find the process `ps -ax | grep immugw` and then `kill -15 <pid>`. Windows PowerShell would be `Get-Process immugw* | Stop-Process`.
+
+## Configuration
+
+immugw can be configured using environment variables, flags or a config file.
+
+* `immugw --help` shows you all available flags and environment variables.
+* `/etc/immudb/immugw.toml` is used as a default configuration file
+
+### Environment variables
+
+The environment variables are the most popular way to configure Docker container:
+
+```bash
+  IMMUGW_ADDRESS=0.0.0.0
+  IMMUGW_PORT=3323
+  IMMUGW_IMMUDB_ADDRESS=127.0.0.1
+  IMMUGW_IMMUDB_PORT=3322
+  IMMUGW_DIR=.
+  IMMUGW_PIDFILE=
+  IMMUGW_LOGFILE=
+  IMMUGW_DETACHED=false
+  IMMUGW_MTLS=false
+  IMMUGW_SERVERNAME=localhost
+  IMMUGW_AUDIT=false
+  IMMUGW_AUDIT_INTERVAL=5m
+  IMMUGW_AUDIT_USERNAME=immugwauditor
+  IMMUGW_AUDIT_PASSWORD=
+  IMMUGW_PKEY=./tools/mtls/4_client/private/localhost.key.pem
+  IMMUGW_CERTIFICATE=./tools/mtls/4_client/certs/localhost.cert.pem
+  IMMUGW_CLIENTCAS=./tools/mtls/2_intermediate/certs/ca-chain.cert.pem
+```
+
+
+## immuadmin
+
+immuadmin can be used to install and manage the immugw service for Windows and Linux. immuadmin is part of the immugw repository.
+'git clone https://github.com/codenotary/immudb.git'
+
+### Linux
+
+```bash
+GOOS=linux GOARCH=amd64 make immuadmin-static 
+```
+
+### Windows (by component)
+
+```bash
+GOOS=windows GOARCH=amd64 make immuadmin-static
+```
+
+## immugw service
+
+```
+# install immugw service
+./immugw service install
+
+# check current immugw service status
+./immugw service status
+
+# stop immugw service
+./immugw service stop
+
+# start immugw service
+./immugw service start
+```
+
+The linux service is using the following defaults:
+
+| File or configuration   | location           |
+| ----------------------- | ------------------ |
+| all configuration files | /etc/immudb        |
+| pid file                | /var/lib/immudb/immugw.pid |
+| log files               | /var/log/immudb    |
+
+## Use immugw
+
+`immugw help` is a good starting point
+
+```bash
+immu gateway: a smart REST proxy for immudb - the lightweight, high-speed immutable database for systems and applications.
+It exposes all gRPC methods with a REST interface while wrapping all SAFE endpoints with a verification service.
+
+Environment variables:
+  IMMUGW_ADDRESS=127.0.0.1
+  IMMUGW_PORT=3323
+  IMMUGW_IMMUDB_ADDRESS=127.0.0.1
+  IMMUGW_IMMUDB_PORT=3322
+  IMMUGW_DIR=.
+  IMMUGW_PIDFILE=
+  IMMUGW_LOGFILE=
+  IMMUGW_DETACHED=false
+  IMMUGW_MTLS=false
+  IMMUGW_SERVERNAME=localhost
+  IMMUGW_PKEY=./tools/mtls/4_client/private/localhost.key.pem
+  IMMUGW_CERTIFICATE=./tools/mtls/4_client/certs/localhost.cert.pem
+  IMMUGW_CLIENTCAS=./tools/mtls/2_intermediate/certs/ca-chain.cert.pem
+  IMMUGW_AUDIT="false"
+  IMMUGW_AUDIT_INTERVAL = "5m"
+  IMMUGW_AUDIT_USERNAME=""
+  IMMUGW_AUDIT_PASSWORD=""
+
+Usage:
+  immugw [flags]
+  immugw [command]
+
+Available Commands:
+  help        Help about any command
+  version     Show the immugw version
+
+Flags:
+  -a, --address string            immugw host address (default "127.0.0.1")
+      --audit                     enable audit mode (continuously fetches latest root from server, checks consistency against a local root and saves the latest root locally)
+      --audit-interval duration   interval at which audit should run (default 5m0s)
+      --audit-password string     immudb password used to login during audit
+      --audit-username string     immudb username used to login during audit (default "immugwauditor")
+      --certificate string        server certificate file path (default "./tools/mtls/4_client/certs/localhost.cert.pem")
+      --clientcas string          clients certificates list. Aka certificate authority (default "./tools/mtls/2_intermediate/certs/ca-chain.cert.pem")
+      --config string             config file (default path are configs or $HOME. Default filename is immugw.toml)
+  -d, --detached                  run immudb in background
+      --dir string                program files folder (default ".")
+  -h, --help                      help for immugw
+  -k, --immudb-address string     immudb host address (default "127.0.0.1")
+  -j, --immudb-port int           immudb port number (default 3322)
+      --logfile string            log path with filename. E.g. /tmp/immugw/immugw.log
+  -m, --mtls                      enable mutual tls
+      --pidfile string            pid path with filename. E.g. /var/run/immugw.pid
+      --pkey string               server private key path (default "./tools/mtls/4_client/private/localhost.key.pem")
+  -p, --port int                  immugw port number (default 3323)
+      --servername string         used to verify the hostname on the returned certificates (default "localhost")
+
+Use "immugw [command] --help" for more information about a command.
+```
+
+## API
+
+### immugw RESTful API reference
+
+You can find the swagger schema here:
+
+[swagger immugw](https://github.com/codenotary/immugw/blob/master/pkg/api/gw.schema.swagger.json)
+
+If you want to run the Swagger UI, simply run the following Docker command after you cloned this repo:
+
+```bash
+docker run -d -it -p 8081:8080 --name swagger-immugw -v ${PWD}/pkg/api/gw.schema.swagger.json:/openapi.json -e SWAGGER_JSON=/openapi.json  swaggerapi/swagger-ui
+```
+### Curl examples
+
+[Curl code snippets](curl.md)
+
+## Auditor
+
+Auditors make sure that the data consistency is guaranteed inside immudb. They do a random key value verification and an interval-based Merkle-tree consistency check (5 minutes default). The immugw and the immuclient provide auditor functionality that runs as a daemon process. It is recommended to run immugw and immuclient on different machines than immudb, so any tampering on the immudb server is automatically detected.
+
+The results of the auditors are provided by a Prometheus end point.
+
+### immugw auditor
+
+Start interactive:
+`immugw --audit`
+
+Service configuration:
+To enable auditor, you need to edit /etc/immudb/immugw.toml and add the following section:
+
+```bash
+audit = true # false is default
+audit-interval = "5m" # suffixes: "s", "m", "h", examples: 10s, 5m 1h
+audit-username = "" # when immudb authentication is enabled, use read-only user credentials here
+audit-password = "" # and the password
+```
+Restart the immugw service afterwards - `immuadmin service immugw restart`
+
+**immugw Port: 9476 - http://immugw-auditor:9476/metrics**
+
+example output: 
+
+```bash
+# HELP immugw_audit_curr_root_per_server Current root index used for the latest audit.
+# TYPE immugw_audit_curr_root_per_server gauge
+immugw_audit_curr_root_per_server{server_address="127.0.0.1:3322",server_id="br8eugq036tfln0ct6o0"} 2
+# HELP immugw_audit_prev_root_per_server Previous root index used for the latest audit.
+# TYPE immugw_audit_prev_root_per_server gauge
+immugw_audit_prev_root_per_server{server_address="127.0.0.1:3322",server_id="br8eugq036tfln0ct6o0"} 2
+# HELP immugw_audit_result_per_server Latest audit result (1 = ok, 0 = tampered).
+# TYPE immugw_audit_result_per_server gauge
+immugw_audit_result_per_server{server_address="127.0.0.1:3322",server_id="br8eugq036tfln0ct6o0"} 1
+# HELP immugw_audit_run_at_per_server Timestamp in unix seconds at which latest audit run.
+# TYPE immugw_audit_run_at_per_server gauge
+immugw_audit_run_at_per_server{server_address="127.0.0.1:3322",server_id="br8eugq036tfln0ct6o0"} 1.590757033502689e+09
+```
+
+## License
+
+immugw is [Apache v2.0 License](https://github.com/codenotary/immugw/blob/master/LICENSE).

--- a/src/master/jumpstart.md
+++ b/src/master/jumpstart.md
@@ -34,7 +34,7 @@ SDKs make it comfortable to talk to the server from your favourite language, wit
 
 The most well-known immudb SDK is written in [Golang](https://golang.org/), but there are SDKs available for Python, NodeJS, Java and others.
 
-For other unsupported programming languages, [immugw](https://docs.immudb.io/master/immugw/) provides a REST gateway that can be used to talk to the server via generic HTTP.
+For other unsupported programming languages, [immugw](/master/immugw/) provides a REST gateway that can be used to talk to the server via generic HTTP.
 
 </WrappedSection>
 
@@ -139,6 +139,12 @@ Install the package using pip:
 
 ::: tab Node.js
 
+Install the package using npm:
+
+```shell
+    npm install immudb-node
+```
+
 Include the immudb-node as a dependency in your project.
 
 ```javascript
@@ -171,7 +177,7 @@ Creating a Client.
 :::
 
 ::: tab Others
-If you're using another language, then read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another language, then read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -233,6 +239,27 @@ ic.login("immudb","immudb")
 
 ::: tab Node.js
 ```javascript
+const ImmudbClient = require('immudb-node');
+
+const cl = new ImmudbClient();
+
+(async () => {
+  try {
+    const loginReq = { user: 'immudb', password: 'immudb' }
+    const loginRes = await cl.login(loginReq)
+// ...
+} catch (err) {
+    console.log(err)
+  }
+})()
+```
+
+You can also use exported types in your TypeScript projects:
+
+```typescript
+import ImmudbClient from 'immudb-node'
+import Parameters from 'immudb-node/types/parameters'
+
 const cl = new ImmudbClient();
 
 (async () => {
@@ -249,11 +276,11 @@ const cl = new ImmudbClient();
 
 ::: tab .Net
 This feature is not yet supported or not documented.
-Do you want to make a feature request or help out? Open an issue on [java sdk github project](https://github.com/codenotary/immudb4dotnet/issues/new)
+Do you want to make a feature request or help out? Open an issue on [.Net sdk github project](https://github.com/codenotary/immudb4dotnet/issues/new)
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::
@@ -303,7 +330,7 @@ Do you want to make a feature request or help out? Open an issue on [.Net sdk gi
 :::
 
 ::: tab Others
-If you're using another development language, please read up on our [immugw](https://docs.immudb.io/master/immugw/) option.
+If you're using another development language, please read up on our [immugw](/master/immugw/) option.
 :::
 
 ::::


### PR DESCRIPTION
- [x] Here the Node.js documentation gives an example in TypeScript without specifying it. My suggestion is to either remove the typing or noticing that this code is not JavaScript.
- [x] we forgot to add the missing command $ npm install immudb-node to the documentation.
- [x] The links to immugw are not working.
- [x] .Net tab incorrectly links to Java documentation