### PR TITLE
Update algolia indexing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '14.18.3'
-          cache: 'npm'
+          node-version: "14.18.3"
+          cache: "npm"
 
       - name: Node version
         run: node --version
@@ -33,6 +33,9 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Index algolia
+        run: npm run algolia:index
 
   quality-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: create .env
+        run: |
+          cat <<EOF > .env
+          ALGOLIA_API_KEY=${{secrets.ALGOLIA_API_KEY}}
+          ALGOLIA_APP_ID=${{secrets.ALGOLIA_API_ID}}
+          ALGOLIA_INDEX=immudb
+          ALGOLIA_WRIGHT_API_KEY=${{secrets.ALGOLIA_WRIGHT_API_KEY}}
+          EOF
       - uses: actions/setup-node@v2
         with:
           node-version: "14.18.3"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,9 +42,6 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Index algolia
-        run: npm run algolia:index
-
   quality-checks:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Index algolia
+        run: npm run algolia:index
+
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,10 +11,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: create .env
+        run: |
+          cat <<EOF > .env
+          ALGOLIA_API_KEY=${{secrets.ALGOLIA_API_KEY}}
+          ALGOLIA_APP_ID=${{secrets.ALGOLIA_API_ID}}
+          ALGOLIA_INDEX=immudb
+          ALGOLIA_WRIGHT_API_KEY=${{secrets.ALGOLIA_WRIGHT_API_KEY}}
+          EOF
       - uses: actions/setup-node@v2
         with:
-          node-version: '14.18.3'
-          cache: 'npm'
+          node-version: "14.18.3"
+          cache: "npm"
 
       - name: Node version
         run: node --version
@@ -37,8 +45,11 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Index algolia
+        run: npm run algolia:index
+
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
-            github_token: ${{ secrets.GITHUB_TOKEN }}
-            publish_dir: ./docs
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -45,9 +45,6 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Index algolia
-        run: npm run algolia:index
-
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Requirements: node version v14.18.3 (NOT working with latest node versions)
 
 ## Indexing to algolia
 
-From the root directory, enter `algolia:index`.
+From the root directory, enter `npm run algolia:index`.
 
 ## Copyright and license
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Requirements: node version v14.18.3 (NOT working with latest node versions)
 2. From the root directory, enter `npm run dev`.
 3. Open `http://localhost:8080` in your browser.
 
+## Indexing to algolia
+
+From the root directory, enter `algolia:index`.
+
 ## Copyright and license
 
 Homepage and documentation copyright 2017-2021 [Immudb Authors](https://github.com/codenotary/immudb/graphs/contributors). 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3949,7 +3949,7 @@
     "agentkeepalive": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-2.2.0.tgz",
-      "integrity": "sha512-TnB6ziK363p7lR8QpeLC8aMr8EGYBKZTpgzQLfqTs3bR0Oo5VbKdwKf8h0dSzsYrB7lSCgfJnMZKqShvlq5Oyg==",
+      "integrity": "sha1-xdG9SxKQCPEWPyNvhuX66iAm4u8=",
       "dev": true
     },
     "ajv": {
@@ -9571,7 +9571,7 @@
     "load-script": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-      "integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA==",
+      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ=",
       "dev": true
     },
     "loader-runner": {
@@ -9650,7 +9650,7 @@
     "lodash.kebabcase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
-      "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
+      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
       "dev": true
     },
     "lodash.memoize": {
@@ -12606,7 +12606,7 @@
         "jsesc": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
           "dev": true
         }
       }
@@ -14470,7 +14470,7 @@
     "svg-tags": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
-      "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
+      "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
       "dev": true
     },
     "svgo": {
@@ -14677,7 +14677,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "through2": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,121 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@algolia/cache-browser-local-storage": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.2.tgz",
+      "integrity": "sha512-FRweBkK/ywO+GKYfAWbrepewQsPTIEirhi1BdykX9mxvBPtGNKccYAxvGdDCumU1jL4r3cayio4psfzKMejBlA==",
+      "requires": {
+        "@algolia/cache-common": "4.14.2"
+      }
+    },
+    "@algolia/cache-common": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.2.tgz",
+      "integrity": "sha512-SbvAlG9VqNanCErr44q6lEKD2qoK4XtFNx9Qn8FK26ePCI8I9yU7pYB+eM/cZdS9SzQCRJBbHUumVr4bsQ4uxg=="
+    },
+    "@algolia/cache-in-memory": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.2.tgz",
+      "integrity": "sha512-HrOukWoop9XB/VFojPv1R5SVXowgI56T9pmezd/djh2JnVN/vXswhXV51RKy4nCpqxyHt/aGFSq2qkDvj6KiuQ==",
+      "requires": {
+        "@algolia/cache-common": "4.14.2"
+      }
+    },
+    "@algolia/client-account": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.2.tgz",
+      "integrity": "sha512-WHtriQqGyibbb/Rx71YY43T0cXqyelEU0lB2QMBRXvD2X0iyeGl4qMxocgEIcbHyK7uqE7hKgjT8aBrHqhgc1w==",
+      "requires": {
+        "@algolia/client-common": "4.14.2",
+        "@algolia/client-search": "4.14.2",
+        "@algolia/transporter": "4.14.2"
+      }
+    },
+    "@algolia/client-analytics": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.2.tgz",
+      "integrity": "sha512-yBvBv2mw+HX5a+aeR0dkvUbFZsiC4FKSnfqk9rrfX+QrlNOKEhCG0tJzjiOggRW4EcNqRmaTULIYvIzQVL2KYQ==",
+      "requires": {
+        "@algolia/client-common": "4.14.2",
+        "@algolia/client-search": "4.14.2",
+        "@algolia/requester-common": "4.14.2",
+        "@algolia/transporter": "4.14.2"
+      }
+    },
+    "@algolia/client-common": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.2.tgz",
+      "integrity": "sha512-43o4fslNLcktgtDMVaT5XwlzsDPzlqvqesRi4MjQz2x4/Sxm7zYg5LRYFol1BIhG6EwxKvSUq8HcC/KxJu3J0Q==",
+      "requires": {
+        "@algolia/requester-common": "4.14.2",
+        "@algolia/transporter": "4.14.2"
+      }
+    },
+    "@algolia/client-personalization": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.2.tgz",
+      "integrity": "sha512-ACCoLi0cL8CBZ1W/2juehSltrw2iqsQBnfiu/Rbl9W2yE6o2ZUb97+sqN/jBqYNQBS+o0ekTMKNkQjHHAcEXNw==",
+      "requires": {
+        "@algolia/client-common": "4.14.2",
+        "@algolia/requester-common": "4.14.2",
+        "@algolia/transporter": "4.14.2"
+      }
+    },
+    "@algolia/client-search": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.2.tgz",
+      "integrity": "sha512-L5zScdOmcZ6NGiVbLKTvP02UbxZ0njd5Vq9nJAmPFtjffUSOGEp11BmD2oMJ5QvARgx2XbX4KzTTNS5ECYIMWw==",
+      "requires": {
+        "@algolia/client-common": "4.14.2",
+        "@algolia/requester-common": "4.14.2",
+        "@algolia/transporter": "4.14.2"
+      }
+    },
+    "@algolia/logger-common": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.2.tgz",
+      "integrity": "sha512-/JGlYvdV++IcMHBnVFsqEisTiOeEr6cUJtpjz8zc0A9c31JrtLm318Njc72p14Pnkw3A/5lHHh+QxpJ6WFTmsA=="
+    },
+    "@algolia/logger-console": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.2.tgz",
+      "integrity": "sha512-8S2PlpdshbkwlLCSAB5f8c91xyc84VM9Ar9EdfE9UmX+NrKNYnWR1maXXVDQQoto07G1Ol/tYFnFVhUZq0xV/g==",
+      "requires": {
+        "@algolia/logger-common": "4.14.2"
+      }
+    },
+    "@algolia/requester-browser-xhr": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.2.tgz",
+      "integrity": "sha512-CEh//xYz/WfxHFh7pcMjQNWgpl4wFB85lUMRyVwaDPibNzQRVcV33YS+63fShFWc2+42YEipFGH2iPzlpszmDw==",
+      "requires": {
+        "@algolia/requester-common": "4.14.2"
+      }
+    },
+    "@algolia/requester-common": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.2.tgz",
+      "integrity": "sha512-73YQsBOKa5fvVV3My7iZHu1sUqmjjfs9TteFWwPwDmnad7T0VTCopttcsM3OjLxZFtBnX61Xxl2T2gmG2O4ehg=="
+    },
+    "@algolia/requester-node-http": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.2.tgz",
+      "integrity": "sha512-oDbb02kd1o5GTEld4pETlPZLY0e+gOSWjWMJHWTgDXbv9rm/o2cF7japO6Vj1ENnrqWvLBmW1OzV9g6FUFhFXg==",
+      "requires": {
+        "@algolia/requester-common": "4.14.2"
+      }
+    },
+    "@algolia/transporter": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.2.tgz",
+      "integrity": "sha512-t89dfQb2T9MFQHidjHcfhh6iGMNwvuKUvojAj+JsrHAGbuSy7yE4BylhLX6R0Q1xYRoC4Vvv+O5qIw/LdnQfsQ==",
+      "requires": {
+        "@algolia/cache-common": "4.14.2",
+        "@algolia/logger-common": "4.14.2",
+        "@algolia/requester-common": "4.14.2"
+      }
+    },
     "@ampproject/remapping": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
@@ -3230,6 +3345,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -3833,7 +3949,7 @@
     "agentkeepalive": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-2.2.0.tgz",
-      "integrity": "sha1-xdG9SxKQCPEWPyNvhuX66iAm4u8=",
+      "integrity": "sha512-TnB6ziK363p7lR8QpeLC8aMr8EGYBKZTpgzQLfqTs3bR0Oo5VbKdwKf8h0dSzsYrB7lSCgfJnMZKqShvlq5Oyg==",
       "dev": true
     },
     "ajv": {
@@ -3858,55 +3974,24 @@
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
     },
     "algoliasearch": {
-      "version": "3.35.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-3.35.1.tgz",
-      "integrity": "sha512-K4yKVhaHkXfJ/xcUnil04xiSrB8B8yHZoFEhWNpXg23eiCnqvTZw1tn/SqvdsANlYHLJlKl0qi3I/Q2Sqo7LwQ==",
-      "dev": true,
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.2.tgz",
+      "integrity": "sha512-ngbEQonGEmf8dyEh5f+uOIihv4176dgbuOZspiuhmTTBRBuzWu3KCGHre6uHj5YyuC7pNvQGzB6ZNJyZi0z+Sg==",
       "requires": {
-        "agentkeepalive": "^2.2.0",
-        "debug": "^2.6.9",
-        "envify": "^4.0.0",
-        "es6-promise": "^4.1.0",
-        "events": "^1.1.0",
-        "foreach": "^2.0.5",
-        "global": "^4.3.2",
-        "inherits": "^2.0.1",
-        "isarray": "^2.0.1",
-        "load-script": "^1.0.0",
-        "object-keys": "^1.0.11",
-        "querystring-es3": "^0.2.1",
-        "reduce": "^1.0.1",
-        "semver": "^5.1.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "events": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-          "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
-          "dev": true
-        },
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
+        "@algolia/cache-browser-local-storage": "4.14.2",
+        "@algolia/cache-common": "4.14.2",
+        "@algolia/cache-in-memory": "4.14.2",
+        "@algolia/client-account": "4.14.2",
+        "@algolia/client-analytics": "4.14.2",
+        "@algolia/client-common": "4.14.2",
+        "@algolia/client-personalization": "4.14.2",
+        "@algolia/client-search": "4.14.2",
+        "@algolia/logger-common": "4.14.2",
+        "@algolia/logger-console": "4.14.2",
+        "@algolia/requester-browser-xhr": "4.14.2",
+        "@algolia/requester-common": "4.14.2",
+        "@algolia/requester-node-http": "4.14.2",
+        "@algolia/transporter": "4.14.2"
       }
     },
     "alphanum-sort": {
@@ -3987,8 +4072,7 @@
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "2.2.1",
@@ -4442,6 +4526,16 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bl": {
       "version": "4.1.0",
@@ -4897,6 +4991,20 @@
         "y18n": "^4.0.0"
       },
       "dependencies": {
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "lru-cache": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4904,6 +5012,15 @@
           "dev": true,
           "requires": {
             "yallist": "^3.0.2"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
           }
         },
         "yallist": {
@@ -5239,6 +5356,44 @@
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
       "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
       "dev": true
+    },
+    "cli-progress": {
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.11.2.tgz",
+      "integrity": "sha512-lCPoS6ncgX4+rJu5bS3F/iCz17kZ9MPZ6dpuTtI0KXKABkhyXIdYB3Inby1OpaGti3YlI3EeEkM9AuWpelJrVA==",
+      "requires": {
+        "string-width": "^4.2.3"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
+      }
     },
     "cliui": {
       "version": "5.0.0",
@@ -5689,6 +5844,29 @@
             "slash": "^1.0.0"
           },
           "dependencies": {
+            "glob": {
+              "version": "7.2.3",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+              "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+              "dev": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "minimatch": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+              "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
             "pify": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -6348,12 +6526,35 @@
             "pinkie-promise": "^2.0.0"
           },
           "dependencies": {
+            "glob": {
+              "version": "7.2.3",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+              "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+              "dev": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
             "pify": {
               "version": "2.3.0",
               "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
           }
         },
         "pify": {
@@ -6491,6 +6692,58 @@
         "stack-utils": "^1.0.1",
         "to-factory": "^1.0.0",
         "zepto": "^1.2.0"
+      },
+      "dependencies": {
+        "algoliasearch": {
+          "version": "3.35.1",
+          "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-3.35.1.tgz",
+          "integrity": "sha512-K4yKVhaHkXfJ/xcUnil04xiSrB8B8yHZoFEhWNpXg23eiCnqvTZw1tn/SqvdsANlYHLJlKl0qi3I/Q2Sqo7LwQ==",
+          "dev": true,
+          "requires": {
+            "agentkeepalive": "^2.2.0",
+            "debug": "^2.6.9",
+            "envify": "^4.0.0",
+            "es6-promise": "^4.1.0",
+            "events": "^1.1.0",
+            "foreach": "^2.0.5",
+            "global": "^4.3.2",
+            "inherits": "^2.0.1",
+            "isarray": "^2.0.1",
+            "load-script": "^1.0.0",
+            "object-keys": "^1.0.11",
+            "querystring-es3": "^0.2.1",
+            "reduce": "^1.0.1",
+            "semver": "^5.1.0",
+            "tunnel-agent": "^0.6.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "events": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+          "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
+          "dev": true
+        },
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+          "dev": true
+        }
       }
     },
     "dom-converter": {
@@ -7498,6 +7751,13 @@
       "integrity": "sha512-Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw==",
       "dev": true
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -7587,9 +7847,9 @@
       "dev": true
     },
     "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.6.tgz",
+      "integrity": "sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg==",
       "dev": true
     },
     "forever-agent": {
@@ -7637,6 +7897,11 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
       }
+    },
+    "fs": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
     },
     "fs-constants": {
       "version": "1.0.0",
@@ -7815,16 +8080,33 @@
       "dev": true
     },
     "glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "glob-parent": {
@@ -7891,6 +8173,29 @@
         "slash": "^2.0.0"
       },
       "dependencies": {
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
         "pify": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -9266,7 +9571,7 @@
     "load-script": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ=",
+      "integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA==",
       "dev": true
     },
     "loader-runner": {
@@ -10027,6 +10332,27 @@
         "which": "1"
       },
       "dependencies": {
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
         "semver": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -10112,6 +10438,29 @@
         "sass-graph": "2.2.5",
         "stdout-stream": "^1.4.0",
         "true-case-path": "^1.0.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "noop-logger": {
@@ -12495,6 +12844,29 @@
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "requires": {
         "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "ripemd160": {
@@ -12561,6 +12933,29 @@
         "lodash": "^4.0.0",
         "scss-tokenizer": "^0.2.3",
         "yargs": "^13.3.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "sass-loader": {
@@ -13017,6 +13412,20 @@
           "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
           "dev": true
         },
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -13037,6 +13446,15 @@
           "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
           "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
           "dev": true
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
         },
         "mkdirp": {
           "version": "1.0.4",
@@ -13341,6 +13759,11 @@
       "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
       "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E=",
       "dev": true
+    },
+    "slugify": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
+      "integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ=="
     },
     "smoothscroll-polyfill": {
       "version": "0.4.4",
@@ -13974,6 +14397,29 @@
             "ms": "2.0.0"
           }
         },
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
         "mkdirp": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -14231,7 +14677,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
     "through2": {
@@ -14389,6 +14835,29 @@
       "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
       "requires": {
         "glob": "^7.1.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "tty-browserify": {
@@ -15404,6 +15873,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -15838,6 +16308,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "preinstall": "([ ! -f package-lock.json ] && npm install --package-lock-only --ignore-scripts --no-audit); npx npm-force-resolutions",
     "images": "npm run images:fullsize && npm run images:thumbnail",
     "images:fullsize": "sharp -i 'src/.vuepress/public/blog/*.{jpg,png,gif}' -o src/.vuepress/public/blog/fullsize/ resize 1920",
-    "images:thumbnail": "sharp -i 'src/.vuepress/public/blog/*.{jpg,png,gif}' -o src/.vuepress/public/blog/thumbnail/ resize 560"
+    "images:thumbnail": "sharp -i 'src/.vuepress/public/blog/*.{jpg,png,gif}' -o src/.vuepress/public/blog/thumbnail/ resize 560",
+    "algolia:index": "node src/.vuepress/algolia_index.js"
   },
   "repository": {
     "type": "git",
@@ -56,9 +57,14 @@
     "@fortawesome/free-brands-svg-icons": "^5.15.3",
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@fortawesome/vue-fontawesome": "^0.1.9",
+    "algoliasearch": "^4.14.2",
     "axios": "^0.21.1",
+    "cli-progress": "^3.11.2",
     "f": "^1.4.0",
+    "fs": "0.0.1-security",
+    "glob": "^8.0.3",
     "reading-time": "^1.2.0",
+    "slugify": "^1.6.5",
     "vue-filter-date-format": "^1.3.1",
     "vue-github-button": "^1.2.0",
     "vue-owl-carousel": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@vuepress/plugin-blog": "^1.9.2",
     "@vuepress/plugin-google-analytics": "^1.9.7",
     "ansi-regex": "^5.0.1",
-    "dotenv": "^8.2.0",
+    "dotenv": "^8.6.0",
     "jimp": "^0.13.0",
     "nth-check": "^2.1.1",
     "responsive-loader": "^1.2.0",

--- a/src/.vuepress/algolia_index.js
+++ b/src/.vuepress/algolia_index.js
@@ -1,0 +1,140 @@
+const algoliasearch = require('algoliasearch')
+const glob = require("glob")
+const {
+  readFileSync
+} = require("fs")
+const client = algoliasearch('2MY54GAA5W', '5ba37f0a8d8da6bbbe202e6707ca1998')
+const index = client.initIndex('immudb')
+var MarkdownIt = require('markdown-it');
+const cliProgress = require('cli-progress');
+var slugify = require('slugify')
+
+
+try {
+  /**
+   * For this documentation we use vue press.
+   * VuePress uses file system for routing. That means for creating a new documentation
+   * you need to create a new file as an md and this will create a new route for you.
+   * 
+   * So for mapping all the routes - documents in this project we just load all the .md files
+   * under src folder.
+   */
+  glob("./src/**/*.md", {}, async function (er, files) {
+    const itemsToIndex = []
+
+    /**
+     * We loop through all md files so we can scrap each one of them and finally index them into algolia.
+     */
+    files.map(file => {
+      /**
+       * We open each file of the loop.
+       * We do this for creating sections and after selecting one result
+       * navigates you in the hash as well.
+       */
+      const content = readFileSync(file).toString();
+
+      /**
+       * lvl1 and lvl2 variables remained from he previous indexing and represents 
+       * The h1 and the header 2 of the scrapped page.
+       * H1 - lvl1 is the title of the document
+       * H2 - lvl is the sections - hash
+       */
+      let lvl1 = ''
+      let lvl2 = ''
+
+      /**
+       * In vue press README.md is like index.html so when a README.md exists is not appearing in the url
+       * VuePress adds .html in the end of each file.
+       * ex. master/my/path/README.md becomes https://my-doc/master/my/path
+       * ex2.  master/my/path/about.md becomes https://my-doc/master/my/path/about.html
+       * 
+       * For this reason i remove the README.mf and replace the .md with .html
+       */
+      const url = file.replace('./src', 'https://docs.immudb.io').replace('README.md', '').replace('.md', '.html');
+
+      /**
+       * Using MarkdownIt for opening md files and parse sections
+       */
+      var md = new MarkdownIt();
+      var result = md.parse(content, {});
+      return result.map((r, i) => {
+        /**
+         * The h1 is the lvl1 key in indexing document 
+         * and remains as the main lvl1 for the rest of the file.
+         */
+        if (r.tag == 'h1' && !r.type.endsWith('close')) {
+          lvl1 = result[i + 1].content
+        }
+
+        /**
+         * The h2 is the lvl2 key in indexing document 
+         * and represents the current indexing section.
+         */
+        if (r.tag == 'h2' && !r.type.endsWith('close')) {
+          lvl2 = result[i + 1].content
+        }
+
+        /**
+         * We create the indexing item to push.
+         * from lvl3 to lvl6 not sure how i could handle that.
+         * 
+         * Needs further investigation.
+         * 
+         * The anchor in the h2 - lvl of the current section that creates the id of that.
+         * We use that for visiting the section.
+         * 
+         * ex. my/path/about.html#who-we-are
+         */
+        if (!!r.content) {
+          itemsToIndex.push({
+            anchor: slugify(lvl2.toLowerCase()),
+            content: r.parent != 'h2' ? r.content : null,
+            url,
+            hierarchy: {
+              lvl0: 'Documentation',
+              lvl1,
+              lvl2,
+              lvl3: '',
+              lvl4: '',
+              lvl5: '',
+              lvl6: '',
+            }
+          })
+
+
+        }
+      })
+    })
+
+    /**
+     * Its a big process and for this reason i am using progressBar
+     * and letting the user know that the app is not stuck and actually is processing 
+     */
+    const progressBar = new cliProgress.SingleBar({}, cliProgress.Presets.shades_classic);
+    progressBar.start(itemsToIndex.length, 0);
+
+    /**
+     * Apologies for using for loop instead of Promise.all map
+     * But seems like it wasn't working as expected.
+     * TODO: replace for loop with Promise.all
+     * 
+     * We loop thought all the items and indexing them to algolia
+     */
+    for (let i = 0; i < itemsToIndex.length; i++) {
+      try {
+        await index.saveObject(itemsToIndex[i], {
+          autoGenerateObjectIDIfNotExist: true
+        })
+
+        /**
+         * Updates the progressBar by 1 after successfully index document
+         */
+        progressBar.update(i);
+      } catch (error) {
+        console.log(error);
+      }
+    }
+  })
+} catch (error) {
+  console.log(error)
+}

--- a/src/.vuepress/algolia_index.js
+++ b/src/.vuepress/algolia_index.js
@@ -1,10 +1,11 @@
 const algoliasearch = require('algoliasearch')
+require('dotenv').config()
 const glob = require("glob")
 const {
   readFileSync
 } = require("fs")
-const client = algoliasearch('2MY54GAA5W', '5ba37f0a8d8da6bbbe202e6707ca1998')
-const index = client.initIndex('immudb')
+const client = algoliasearch(process.env.ALGOLIA_APP_ID, process.env.ALGOLIA_WRIGHT_API_KEY)
+const index = client.initIndex(process.env.ALGOLIA_INDEX)
 var MarkdownIt = require('markdown-it');
 const cliProgress = require('cli-progress');
 var slugify = require('slugify')
@@ -21,6 +22,7 @@ try {
    */
   glob("./src/**/*.md", {}, async function (er, files) {
     const itemsToIndex = []
+    await index.clearObjects()
 
     /**
      * We loop through all md files so we can scrap each one of them and finally index them into algolia.

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -88,8 +88,9 @@ module.exports = {
             { text: 'Github', link: 'https://github.com/codenotary/immudb' },
         ],
         algolia: {
-            apiKey: 'e581ef004c097d1f0ff49391645be669',
-            indexName: 'immudb'
+            apiKey: 'a5eea39409c84d4f9e4f9c7bff1fc759',
+            indexName: 'immudb',
+            appId: '2MY54GAA5W',
         }
     },
     plugins: [

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -88,9 +88,9 @@ module.exports = {
             { text: 'Github', link: 'https://github.com/codenotary/immudb' },
         ],
         algolia: {
-            apiKey: 'a5eea39409c84d4f9e4f9c7bff1fc759',
-            indexName: 'immudb',
-            appId: '2MY54GAA5W',
+            apiKey: process.env.ALGOLIA_API_KEY,
+            indexName: process.env.ALGOLIA_INDEX,
+            appId: process.env.ALGOLIA_APP_ID,
         }
     },
     plugins: [

--- a/src/.vuepress/theme/components/AlgoliaSearchBox.vue
+++ b/src/.vuepress/theme/components/AlgoliaSearchBox.vue
@@ -62,7 +62,6 @@ export default {
             inputSelector: '#' + (this.inputId ? this.inputId : 'algolia-search-input'),
             // #697 Make docsearch work well at i18n mode.
             algoliaOptions: Object.assign({
-              'facetFilters': [`lang:${lang}`].concat(algoliaOptions.facetFilters || [])
             }, algoliaOptions),
             handleSelected: (input, event, suggestion) => {
               const { pathname, hash } = new URL(suggestion.url)


### PR DESCRIPTION
Updated algolia indexing. I am having some assumptions about the content parsed. It possibly needs better clearance of the text.

TODO: Algolia logo URL navigates to https://www.algolia.com/docsearch and we want to make it navigate to https://www.algolia.com Quick investigation didn't cause any results.

For running algolia indexing, from the root directory, enter `npm run algolia:index`.