### PR TITLE
Fix performance-report job failing on every PR

### DIFF
--- a/.github/workflows/deploy-vuepress.yml
+++ b/.github/workflows/deploy-vuepress.yml
@@ -150,6 +150,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      pull-requests: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -157,7 +161,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
-          name: vuepress-dist
+          name: vitepress-dist
           path: docs/
 
       - name: Analyze bundle size
@@ -174,6 +178,7 @@ jobs:
       - name: Comment PR
         uses: actions/github-script@v7
         if: github.event_name == 'pull_request'
+        continue-on-error: true  # Dependabot and fork PRs get a read-only token
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
The `build` job uploads its artifact as `vitepress-dist`, but `performance-report` tried to download `vuepress-dist` — a leftover from the VuePress→VitePress migration in 9b15122e9. The download has failed on **every** pull request since, including PRs that touch no JavaScript at all (e.g. the Go-modules Dependabot PRs).

Fixing the name alone would only move the failure one step down: the workflow declares explicit top-level `permissions:`, so every unlisted scope resolves to `none`, and the `Comment PR` step's `issues.createComment` call would 403. So this also:

- gives `performance-report` its own job-scoped `contents: read` + `pull-requests: write`
- marks the comment step `continue-on-error`, since Dependabot and fork PRs get a read-only token regardless — the job summary still carries the bundle-size report either way

This PR is its own test: `performance-report` only runs on `pull_request`, so a green check here means the fix works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ywTrG8er5rsZ5Uyftiagv