### PR TITLE
Verify the Lighthouse CI job runs on a PR

### DIFF
--- a/.github/workflows/deploy-vuepress.yml
+++ b/.github/workflows/deploy-vuepress.yml
@@ -199,7 +199,7 @@ jobs:
               }
               for (const [url, v] of [...rows].sort())
                 console.log("| `" + url + "` | " + v.join(" | ") + " |");
-            ' >> $GITHUB_STEP_SUMMARY
+            ' | tee -a $GITHUB_STEP_SUMMARY
           else
             echo "_No Lighthouse reports were produced._" >> $GITHUB_STEP_SUMMARY
           fi
@@ -212,7 +212,8 @@ jobs:
           name: lighthouse-reports
           path: .lighthouseci/
           retention-days: 7
-          if-no-files-found: ignore
+          include-hidden-files: true
+          if-no-files-found: warn
 
       - name: Analyze bundle size
         run: |

--- a/.github/workflows/deploy-vuepress.yml
+++ b/.github/workflows/deploy-vuepress.yml
@@ -145,6 +145,8 @@ jobs:
         run: npm run algolia:index
         continue-on-error: true
 
+  # Pull-request only: it audits the built site with Lighthouse and comments
+  # the results, neither of which is meaningful on a push to master.
   performance-report:
     if: github.event_name == 'pull_request'
     needs: build


### PR DESCRIPTION
Adds a comment explaining why \`performance-report\` is gated to \`pull_request\`.

Its real purpose is to exercise the Lighthouse job added in 6172073ee. That job only runs on \`pull_request\`, so pushing it to master proved nothing about whether it works on a runner — specifically whether Chrome is available there and whether the build artifact downloads into \`docs/\` as the config expects.

Expected on this PR: \`performance-report\` goes green, the job summary shows a per-page Lighthouse score table, and a \`lighthouse-reports\` artifact is attached. Accessibility should appear as a warning (0.86–0.91 vs a 0.90 target) without failing the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ywTrG8er5rsZ5Uyftiagv